### PR TITLE
Copy directories to destination dir

### DIFF
--- a/lib/travis_github_deployer/travis_github_deployer.rb
+++ b/lib/travis_github_deployer/travis_github_deployer.rb
@@ -124,7 +124,12 @@ class TravisGithubDeployer
       source = Pathname.new(source_location)
       destination = Pathname.new(destination_repository_dir)
       destination += destination_location
-      FileUtils.copy(source, destination)
+
+      if source_location.end_with?("/")
+        FileUtils.cp_r(source, destination)
+      else
+        FileUtils.copy(source, destination)
+      end
     }
     
   end

--- a/spec/travis_github_deployer_spec.rb
+++ b/spec/travis_github_deployer_spec.rb
@@ -95,6 +95,13 @@ describe "travis github deployer" do
       FileUtils.should_receive(:copy).with(Pathname.new("twofile"), Pathname.new("travis_github_deployer_repository/dir/desttwofile"))
       subject.copy_files_in_destination_repository      
     end    
+
+    it "Should be able to copy a directory recursevly" do
+      subject.should_receive(:files_to_deploy).and_return({ "dir/subdir1/" => "subdir1/", "dir2/" => "dir2/"})
+      FileUtils.should_receive(:cp_r).with(Pathname.new("dir/subdir1/"), Pathname.new("travis_github_deployer_repository/subdir1/"))
+      FileUtils.should_receive(:cp_r).with(Pathname.new("dir2/"), Pathname.new("travis_github_deployer_repository/dir2/"))
+      subject.copy_files_in_destination_repository
+    end
   end
   
   context "Actually committing the files" do

--- a/spec/travis_github_deployer_spec.rb
+++ b/spec/travis_github_deployer_spec.rb
@@ -83,7 +83,7 @@ describe "travis github deployer" do
 
   context "Prepare the changes that need to be made commit" do
     
-    it "should be able to copy a file from the root of the source repository to the root of the destination reportistory" do
+    it "should be able to copy a file from the root of the source repository to the root of the destination repository" do
       subject.should_receive(:files_to_deploy).and_return( { "sourcefile" => ""})
       FileUtils.should_receive(:copy).with(Pathname.new("sourcefile"), Pathname.new("travis_github_deployer_repository"))
       subject.copy_files_in_destination_repository


### PR DESCRIPTION
Hi there,

thank your for this gem. I tried to extend it a little bit to use cp_r to copy directories recursively. This is not the wildcard-solution you have suggested but maybe a good start.
the convention is: when a path ends with a slash on the source side it is considered as a directory.

please for give me for rude mistakes - this is my first ruby contribution.

best regards
philipp
